### PR TITLE
clean: eliminate the unused `Contact.Pnb` field.

### DIFF
--- a/include/box2d-lite/Arbiter.h
+++ b/include/box2d-lite/Arbiter.h
@@ -30,7 +30,7 @@ union FeaturePair
 
 struct Contact
 {
-	Contact() : Pn(0.0f), Pt(0.0f), Pnb(0.0f) {}
+	Contact() : Pn(0.0f), Pt(0.0f) {}
 
 	Vec2 position;
 	Vec2 normal;
@@ -38,7 +38,6 @@ struct Contact
 	float separation;
 	float Pn;	// accumulated normal impulse
 	float Pt;	// accumulated tangent impulse
-	float Pnb;	// accumulated normal impulse for position bias
 	float massNormal, massTangent;
 	float bias;
 	FeaturePair feature;

--- a/src/Arbiter.cpp
+++ b/src/Arbiter.cpp
@@ -58,13 +58,11 @@ void Arbiter::Update(Contact* newContacts, int numNewContacts)
 			{
 				c->Pn = cOld->Pn;
 				c->Pt = cOld->Pt;
-				c->Pnb = cOld->Pnb;
 			}
 			else
 			{
 				c->Pn = 0.0f;
 				c->Pt = 0.0f;
-				c->Pnb = 0.0f;
 			}
 		}
 		else


### PR DESCRIPTION
Hello, @erincatto
The `box2d-lite` is a very useful project for beginners. I am reading the source of this project, and try to figure out how it works.

I have read the publication `How Do Physics Engines Work?` and `Fast and Simple Physics using
Sequential Impulses`.
It looks like the `Contact.Pnb` filed is un-used in the source, and is not mentioned in the publications.

So will it better to remove this field, for clearity?

 